### PR TITLE
fix(k8s): disable traefik ingress in qa cluster

### DIFF
--- a/k8s/qa/scripts/qa-cluster-create.sh
+++ b/k8s/qa/scripts/qa-cluster-create.sh
@@ -30,7 +30,7 @@ echo "Master Interface: $MASTER_IFACE"
 echo "Setting up Rancher k3s cluster on qa-master node..."
 
 # Install k3s server, using the host's default nftables mode.
-lxc exec qa-master -- bash -c "curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC='server --write-kubeconfig-mode 644 --tls-san=$MASTER_IP --flannel-iface=$MASTER_IFACE' sh -"
+lxc exec qa-master -- bash -c "curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC='server --disable=traefik --write-kubeconfig-mode 644 --tls-san=$MASTER_IP --flannel-iface=$MASTER_IFACE' sh -"
 
 echo "Waiting for k3s server on qa-master to become active..."
 lxc exec qa-master -- bash -c 'for i in {1..20}; do systemctl is-active k3s && break || (echo Waiting for k3s server...; sleep 5); done'


### PR DESCRIPTION
Based on the `docs/system-overview-and-migration-analysis.md`, the Traefik ingress controller is not required for the QA cluster. The migration plan specifies a phased approach for handling ingress traffic:
1. **Phase 1:** The existing Java-based `agent-portal-gateway` will be deployed to Kubernetes to manage routing initially. 
2. **Phase 5:** The `agent-portal-gateway` will be replaced by Envoy Proxy as the modern, cloud-native ingress solution. 

Since the routing will be handled first by the `agent-portal-gateway` and then by Envoy, the default Traefik ingress controller that comes with k3s is redundant. Disabling it will free up resources in the QA cluster. 
