### PR TITLE
fix: issue-17 documents service image publishing and upload-artifacts action in legacy workflows

### DIFF
--- a/.github/workflows/legacy-release-api.yml
+++ b/.github/workflows/legacy-release-api.yml
@@ -94,7 +94,7 @@ jobs:
           fi
 
       - name: Upload release metadata
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-metadata
           path: release-metadata/

--- a/.github/workflows/legacy-release-svc.yml
+++ b/.github/workflows/legacy-release-svc.yml
@@ -96,7 +96,7 @@ jobs:
           fi
 
       - name: Upload release metadata
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-metadata
           path: release-metadata/

--- a/.github/workflows/legacy-release-svc.yml
+++ b/.github/workflows/legacy-release-svc.yml
@@ -188,6 +188,8 @@ jobs:
 
           if [ "$MODULE_NAME" = "agent-portal-gateway" ]; then
             BASE_IMAGE_NAME="$MODULE_NAME-legacy"
+          elif [ "$MODULE_NAME" = "documents" ]; then
+            BASE_IMAGE_NAME="document-api-legacy"
           else
             BASE_IMAGE_NAME="$SVC_NAME-api-legacy"
           fi

--- a/.github/workflows/legacy-release-web.yml
+++ b/.github/workflows/legacy-release-web.yml
@@ -74,7 +74,7 @@ jobs:
           fi
 
       - name: Upload release metadata
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-metadata
           path: release-metadata/


### PR DESCRIPTION
This PR contains the following fixes:
* enforce Docker image name override for the documents-service, i.e., `documents` -> `document`
* upgrade upload-artifacts@4 to v7