### PR TITLE
fix: issue-17 override base image name for documents service

### DIFF
--- a/.github/workflows/legacy-release-svc.yml
+++ b/.github/workflows/legacy-release-svc.yml
@@ -188,7 +188,7 @@ jobs:
 
           if [ "$MODULE_NAME" = "agent-portal-gateway" ]; then
             BASE_IMAGE_NAME="$MODULE_NAME-legacy"
-          elif [ "$MODULE_NAME" = "documents" ]; then
+          elif [ "$MODULE_NAME" = "documents-service" ]; then
             BASE_IMAGE_NAME="document-api-legacy"
           else
             BASE_IMAGE_NAME="$SVC_NAME-api-legacy"


### PR DESCRIPTION
This PR contains a fix for overriding the base Docker image name for the documents-service, i.e., `documents-api-legacy` -> `document-api-legacy`.