### PR TITLE
feat: issue-86 improve provisioning of qa k8s cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,4 @@
 **/Chart.lock
 
 # Dev
-**/research/*
 *.tgz

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -295,8 +295,18 @@ flux-suspend: _env-check ## Suspend QA Flux reconciliation
 
 KUBE_PROMETHEUS_STACK_VERSION := 79.3.0
 
+.PHONY: prometheus-operator-crds-install
+prometheus-operator-crds-install: _monitoring-ns-check
+	@helm repo add prometheus-community https://prometheus-community.github.io/helm-charts || true
+	@helm repo update
+	@echo "Installing Prometheus Operator CRDs..."
+	@helm upgrade --install prometheus-operator-crds prometheus-community/prometheus-operator-crds \
+		--namespace $(MONITORING_NS) --create-namespace
+	@echo "Waiting for monitoring.coreos.com CRDs to be registered..."
+	@kubectl wait --for=condition=Established crd/alertmanagers.monitoring.coreos.com --timeout=60s || true
+
 .PHONY: prometheus-stack-install
-prometheus-stack-install: _monitoring-ns-check ## Install Kube Prometheus Stack (Prometheus, Grafana, Alert Manager) in QA
+prometheus-stack-install: prometheus-operator-crds-install ## Install Kube Prometheus Stack (Prometheus, Grafana, Alert Manager) in QA
 	@helm repo add prometheus-community https://prometheus-community.github.io/helm-charts || true
 	@helm repo update
 	@echo "Installing Kube Prometheus Stack using Helm chart v$(KUBE_PROMETHEUS_STACK_VERSION) into $(MONITORING_NS) namespace..."
@@ -1219,21 +1229,25 @@ cluster-qa-monitoring-deploy: _env-check _data-ns-check ## Deploy monitoring sta
 
 	# Elasticsearch
 	$(MAKE) es-operator-deploy
-	@echo "⏳ Waiting 15s for elastic operator..." && sleep 15
+	@echo "⏳ Waiting 30s for Elastic operator..." && sleep 30
 	$(MAKE) es-deploy
 
 	# Prometheus & Grafana stack
 	$(MAKE) prometheus-stack-install
 
-	# MinIO Infra Tenants
+    # Monitoring operator
+	$(MAKE) minio-operator-deploy
+	@echo "⏳ Waiting 15s for MinIO operator..." && sleep 15
+
+	# MinIO Monitoring Tenants
 	$(MAKE) minio-storage-user-secret-create SVC_NAME=loki
 	$(MAKE) minio-storage-config-secret-create SVC_NAME=loki
 	$(MAKE) minio-storage-user-secret-create SVC_NAME=tempo
 	$(MAKE) minio-storage-config-secret-create SVC_NAME=tempo
 	$(MAKE) minio-tenant-deploy SVC_NAME=loki & $(MAKE) minio-tenant-deploy SVC_NAME=tempo & wait
-	@echo "⏳ Waiting 3m for MinIO infra tenants.." && sleep 180
+	@echo "⏳ Waiting 3m for MinIO monitoring tenants.." && sleep 180
 
-    # MinIO Infra Tenant Configuration
+    # MinIO Monitoring Tenant Configuration
 	# Loki
 	$(MAKE) minio-svc-bucket-create SVC_NAME=loki BUCKET_NAME=loki-logs
 	$(MAKE) minio-svc-user-secret-create SVC_NAME=loki COPY_SECRET_NS=$(MONITORING_NS)
@@ -1244,18 +1258,14 @@ cluster-qa-monitoring-deploy: _env-check _data-ns-check ## Deploy monitoring sta
 	$(MAKE) minio-svc-user-secret-create SVC_NAME=tempo COPY_SECRET_NS=$(MONITORING_NS)
 	$(MAKE) minio-svc-user-with-policy-create SVC_NAME=tempo POLICY_FILE=apps/infra/tempo/minio/s3-policy-tempo-traces.json
 
-	# Loki
-	$(MAKE) loki-install
-
-	# Tempo
-	$(MAKE) tempo-install
-
 	# Zipkin (requires Elasticsearch)
 	$(MAKE) zipkin-es-user-secret-create
 	$(MAKE) zipkin-es-user-create
 	$(MAKE) zipkin-install
 
-	# Alloy
+	# Grafana Loki,Tempo and Alloy
+	$(MAKE) loki-install
+	$(MAKE) tempo-install
 	$(MAKE) alloy-install
 
 	@echo "✅ QA cluster monitoring stack deployed!"
@@ -1265,8 +1275,10 @@ cluster-infra-deploy: _env-check ## Deploy all infra apps (except monitoring sta
 	@echo "🚀 Deploying Insurance Hub infra apps (all optional args omitted) into '$(ENV_NAME)' cluster..."
 
 	# Infra operators
+	@if [ "$(ENV_NAME)" = "local-dev" ]; then \
+		$(MAKE) minio-operator-deploy; \
+	fi
 	$(MAKE) postgres-operator-deploy & \
-	$(MAKE) minio-operator-deploy & \
 	$(MAKE) mongodb-operator-install & \
 	$(MAKE) kafka-strimzi-operator-install & wait
 	@echo "⏳ Waiting 15s for infra operators..." && sleep 15
@@ -1274,7 +1286,7 @@ cluster-infra-deploy: _env-check ## Deploy all infra apps (except monitoring sta
 	# Elasticsearch
 	@if [ "$(ENV_NAME)" = "local-dev" ]; then \
   		$(MAKE) es-operator-deploy ; \
-		@echo "⏳ Waiting 15s for elastic operator..." && sleep 15 ; \
+		@echo "⏳ Waiting 15s for Elastic operator..." && sleep 15 ; \
 		$(MAKE) es-deploy ; \
 	fi
 
@@ -1302,8 +1314,6 @@ cluster-infra-deploy: _env-check ## Deploy all infra apps (except monitoring sta
 	$(MAKE) minio-storage-config-secret-create SVC_NAME=document
 	$(MAKE) minio-storage-user-secret-create SVC_NAME=payment
 	$(MAKE) minio-storage-config-secret-create SVC_NAME=payment
-	$(MAKE) minio-storage-user-secret-create SVC_NAME=loki
-	$(MAKE) minio-storage-config-secret-create SVC_NAME=loki
 	$(MAKE) minio-tenant-deploy SVC_NAME=document & $(MAKE) minio-tenant-deploy SVC_NAME=payment & wait
 	@echo "⏳ Waiting 3m for MinIO service tenants.." && sleep 180
 

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -1389,7 +1389,11 @@ cluster-svc-deploy:  _env-check ## Deploy all services into either local-dev or 
 	@SVC_NAMES="web-vue,agent-portal-gateway,auth,product,policy-search,dashboard,policy,pricing,document,payment,chat" ; \
 	SVC_NAMES=$$(echo "$$SVC_NAMES" | tr ',' ' ') ; \
 	for svc in $$SVC_NAMES ; do \
-		$(MAKE) svc-load-delete-deploy SVC_NAME=$$svc ; \
+		if [ "$(ENV_NAME)" = "local-dev" ]; then \
+			$(MAKE) svc-load-delete-deploy SVC_NAME=$$svc ; \
+		else \
+			$(MAKE) svc-deploy SVC_NAME=$$svc ; \
+		fi ; \
 	done
 	@echo "⏳ Waiting 60s for services..." && sleep 60
 

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -906,23 +906,30 @@ MONGODB_OPERATOR_VERSION := 0.13.0
 MONGO_ROOT_USER_PWD ?= mongoRootUserPwd
 MONGO_PRODUCT_USER_PWD ?= mongoProductUserPwd
 
-.PHONY: mongodb-operator-install
-mongodb-operator-install: _env-check ## Install MongoDB Community Operator
+.PHONY: mongodb-crds-install
+mongodb-crds-install: _env-check ## Install MongoDB Community Operator CRDs
 	@kubectl get namespace "$(DATA_NS)" >/dev/null 2>&1 || kubectl create namespace "$(DATA_NS)"
 	@helm repo add mongodb https://mongodb.github.io/helm-charts || true
 	@helm repo update
-	@echo "Installing MongoDB operator v$(MONGODB_OPERATOR_VERSION) into $(DATA_NS) namespace..."
-	@helm upgrade --install mongodb-operator mongodb/community-operator \
-	    --version "$(MONGODB_OPERATOR_VERSION)" \
+	@echo "Installing MongoDB Community Operator CRDs into $(DATA_NS) namespace..."
+	@helm upgrade --install mongodb-operator-crds mongodb/community-operator-crds \
 	    --namespace "$(DATA_NS)"
 	@echo "Waiting for MongoDBCommunity CRD to be registered..."
-	@kubectl wait --for=condition=Established crd/mongodbcommunity.mongodb.com --timeout=60s || true
+	@kubectl wait --for=condition=Established crd/mongodbcommunity.mongodbcommunity.mongodb.com --timeout=60s || true
 	@echo "Waiting until MongoDBCommunity custom resource is accepted by API server..."
-	@until kubectl get mongodbcommunity.mongodb.com --all-namespaces >/dev/null 2>&1; do \
+	@until kubectl get mongodbcommunity --all-namespaces >/dev/null 2>&1; do \
 		echo "  MongoDBCommunity CR still not usable, waiting..."; \
 		sleep 2; \
 	done
-	@echo "✅ MongoDB operator deployment completed and CRDs are ready."
+	@echo "✅ MongoDB Community Operator CRDs are installed and ready."
+
+.PHONY: mongodb-operator-install
+mongodb-operator-install: mongodb-crds-install ## Install MongoDB Community Operator
+	@echo "Installing MongoDB operator v$(MONGODB_OPERATOR_VERSION) into $(DATA_NS) namespace..."
+	@helm upgrade --install mongodb-operator mongodb/community-operator \
+	   --version "$(MONGODB_OPERATOR_VERSION)" \
+	   --namespace "$(DATA_NS)"
+	@echo "✅ MongoDB operator deployment initiated."
 
 .PHONY: mongodb-operator-uninstall
 mongodb-operator-uninstall: _env-check ## Delete MongoDB Community Operator

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -569,10 +569,19 @@ ECK_OPERATOR_VERSION := 3.2.0
 .PHONY: es-operator-deploy
 es-operator-deploy: _env-check ## Deploy Elastic Cloud on Kubernetes (ECK) Operator
 	@echo "Deploying ECK operator v$(ECK_OPERATOR_VERSION) into 'elastic-system' namespace..."
-	@kubectl create -f https://download.elastic.co/downloads/eck/$(ECK_OPERATOR_VERSION)/crds.yaml || true
+	@echo "Applying ECK CRDs..."
+	@kubectl apply -f https://download.elastic.co/downloads/eck/$(ECK_OPERATOR_VERSION)/crds.yaml
+	@echo "Waiting for Elasticsearch CRD to be registered..."
+	@kubectl wait --for=condition=Established crd/elasticsearches.elasticsearch.k8s.elastic.co --timeout=60s || true
+	@echo "Waiting until Elasticsearch custom resource is accepted by API server..."
+	@until kubectl get elasticsearches.elasticsearch.k8s.elastic.co --all-namespaces >/dev/null 2>&1; do \
+		echo "  Elasticsearch CR still not usable, waiting..."; \
+		sleep 2; \
+	done
+	@echo "Applying ECK operator deployment..."
 	@kubectl apply --server-side -f https://download.elastic.co/downloads/eck/$(ECK_OPERATOR_VERSION)/operator.yaml
-	@echo "✅ ECK operator deployment initiated."
-	
+	@echo "✅ ECK operator deployment completed and Elasticsearch CRD is ready."
+
 .PHONY: es-operator-delete
 es-operator-delete: _env-check ## Delete Elastic Cloud on Kubernetes (ECK) Operator
 	@echo "Deleting ECK operator v$(ECK_OPERATOR_VERSION) from 'elastic-system' namespace..."
@@ -581,7 +590,7 @@ es-operator-delete: _env-check ## Delete Elastic Cloud on Kubernetes (ECK) Opera
 	@echo "🗑 ECK operator and namespace 'elastic-system' deleted."
 
 .PHONY: es-deploy
-es-deploy: _env-check es-operator-deploy ## Deploy Elasticsearch cluster
+es-deploy: _env-check _data-ns-check es-operator-deploy ## Deploy Elasticsearch cluster
 	@echo "Deploying Elasticsearch cluster into '$(DATA_NS)' namespace...";
 	@kubectl apply --server-side -n "$(DATA_NS)" -f "$(OVERLAYS_FILE_PATH)"/infra/elastic/elasticsearch.yaml;
 	@echo "✅ Elasticsearch cluster deployment initiated. Check status with: make es-status"

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -659,16 +659,39 @@ es-exporter-delete: _env-check ## Delete Prometheus Elasticsearch exporter
 
 STRIMZI_OPERATOR_VERSION := 0.48.0
 
+.PHONY: kafka-strimzi-operator-install
 kafka-strimzi-operator-install: _env-check ## Install Strimzi Kafka operator
 	@kubectl get namespace kafka-system >/dev/null 2>&1 || kubectl create namespace kafka-system
 	@helm repo add strimzi https://strimzi.io/charts/ || true
 	@helm repo update
 	@echo "Installing Strimzi Kafka operator v$(STRIMZI_OPERATOR_VERSION) into 'kafka-system' namespace..."
 	@helm upgrade --install strimzi-operator strimzi/strimzi-kafka-operator \
-		--version $(STRIMZI_OPERATOR_VERSION) \
-		--namespace kafka-system \
-		--set watchNamespaces={"$(DATA_NS)"}
-	@echo "✅ Strimzi Kafka operator installation initiated."
+	    --version $(STRIMZI_OPERATOR_VERSION) \
+	    --namespace kafka-system \
+	    --set watchNamespaces={"$(DATA_NS)"}
+
+	@echo "Waiting for Kafka CRD to be registered..."
+	@kubectl wait --for=condition=Established crd/kafkas.kafka.strimzi.io --timeout=60s || true
+	@echo "Waiting for KafkaNodePool CRD to be registered (if present in this Strimzi version)..."
+	@kubectl wait --for=condition=Established crd/kafkanodepools.kafka.strimzi.io --timeout=60s || true
+
+	@echo "Waiting until Kafka custom resource is accepted by API server..."
+	@until kubectl get kafkas.kafka.strimzi.io --all-namespaces >/dev/null 2>&1; do \
+		echo "  Kafka CR still not usable, waiting..."; \
+		sleep 2; \
+	done
+
+	@echo "Waiting until KafkaNodePool custom resource is accepted by API server (if CRD exists)..."
+	@if kubectl get crd kafkanodepools.kafka.strimzi.io >/dev/null 2>&1; then \
+		until kubectl get kafkanodepools.kafka.strimzi.io --all-namespaces >/dev/null 2>&1; do \
+			echo "  KafkaNodePool CR still not usable, waiting..."; \
+			sleep 2; \
+		done; \
+	else \
+		echo "  KafkaNodePool CRD not found, skipping readiness wait for KafkaNodePool."; \
+	fi
+
+	@echo "✅ Strimzi Kafka operator deployment completed and Kafka CRDs are ready."
 
 kafka-strimzi-operator-uninstall: _env-check ## Uninstall Strimzi Kafka operator
 	@echo "Uninstalling Strimzi Kafka operator..."

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -1393,6 +1393,6 @@ cluster-svc-deploy:  _env-check ## Deploy all services into either local-dev or 
 	done
 	@echo "⏳ Waiting 60s for services..." && sleep 60
 
-	@echo "✅ Service apps deployed to local-dev cluster!"
-	@kubectl get pods | grep -E "web|agent|api"
-	@kubectl top pods | grep -E "web|agent|api"
+	@echo "✅ Service apps deployed to '$(ENV_NAME)' cluster!"
+	@kubectl get pods | grep -E "web|agent|auth|api"
+	@kubectl top pods | grep -E "web|agent|auth|api"

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -575,7 +575,7 @@ es-operator-delete: _env-check ## Delete Elastic Cloud on Kubernetes (ECK) Opera
 	@echo "🗑 ECK operator and namespace 'elastic-system' deleted."
 
 .PHONY: es-deploy
-es-deploy: _env-check ## Deploy Elasticsearch cluster
+es-deploy: _env-check es-operator-deploy ## Deploy Elasticsearch cluster
 	@echo "Deploying Elasticsearch cluster into '$(DATA_NS)' namespace...";
 	@kubectl apply --server-side -n "$(DATA_NS)" -f "$(OVERLAYS_FILE_PATH)"/infra/elastic/elasticsearch.yaml;
 	@echo "✅ Elasticsearch cluster deployment initiated. Check status with: make es-status"
@@ -754,7 +754,14 @@ MINIO_ROOT_USER_PWD ?= minioRootUserPwd
 minio-operator-deploy: _env-check ## Deploy MinIO operator
 	@echo "Deploying MinIO operator v$(MINIO_OPERATOR_VERSION) into 'minio-operator' namespace..."
 	@kubectl kustomize "$(OVERLAYS_FILE_PATH)"/infra/minio/operator | kubectl apply --server-side -f -
-	@echo "✅ MinIO operator deployment initiated."
+	@echo "Waiting for MinIO Tenant CRD to be registered..."
+	@kubectl wait --for=condition=Established crd/tenants.minio.min.io --timeout=60s || true
+	@echo "Waiting until Tenant custom resource is accepted by API server..."
+	@until kubectl get tenants.minio.min.io --all-namespaces >/dev/null 2>&1; do \
+		echo "  Tenant CR still not usable, waiting..."; \
+		sleep 2; \
+	done
+	@echo "✅ MinIO operator deployment completed and Tenant CRD is ready."
 
 .PHONY: minio-operator-delete
 minio-operator-delete: _env-check ## Delete MinIO operator
@@ -1234,14 +1241,10 @@ cluster-qa-monitoring-deploy: _env-check _data-ns-check ## Deploy monitoring sta
 	$(MAKE) prometheus-stack-install
 
 	# Elasticsearch
-	$(MAKE) es-operator-deploy
-	@echo "⏳ Waiting 30s for Elastic operator..." && sleep 30
 	$(MAKE) es-deploy
-
 
     # Monitoring operator
 	$(MAKE) minio-operator-deploy
-	@echo "⏳ Waiting 15s for MinIO operator..." && sleep 15
 
 	# MinIO Monitoring Tenants
 	$(MAKE) minio-storage-user-secret-create SVC_NAME=loki
@@ -1285,12 +1288,10 @@ cluster-infra-deploy: _env-check ## Deploy all infra apps (except monitoring sta
 	$(MAKE) postgres-operator-deploy & \
 	$(MAKE) mongodb-operator-install & \
 	$(MAKE) kafka-strimzi-operator-install & wait
-	@echo "⏳ Waiting 15s for infra operators..." && sleep 15
+	@echo "⏳ Waiting 30s for infra operators..." && sleep 30
 
 	# Elasticsearch
 	@if [ "$(ENV_NAME)" = "local-dev" ]; then \
-  		$(MAKE) es-operator-deploy ; \
-		@echo "⏳ Waiting 15s for Elastic operator..." && sleep 15 ; \
 		$(MAKE) es-deploy ; \
 	fi
 

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -488,9 +488,15 @@ PG_SVC_USER_PWD ?= pgSvcUserPwd
 .PHONY: postgres-operator-deploy
 postgres-operator-deploy: _env-check ## Deploy CloudNativePG operator
 	@echo "Deploying CloudNativePG operator v$(CLOUDNATIVE_PG_VERSION) into 'cnpg-system' namespace..."
-	@kubectl apply --server-side -f https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v$(CLOUDNATIVE_PG_VERSION)/cnpg-"$(CLOUDNATIVE_PG_VERSION)".yaml
-	@echo "✅ CloudNativePG operator deployment initiated."
-
+	@kubectl apply --server-side -f https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v$(CLOUDNATIVE_PG_VERSION)/cnpg-$(CLOUDNATIVE_PG_VERSION).yaml
+	@echo "Waiting for CloudNativePG CRDs to be registered..."
+	@kubectl wait --for=condition=Established crd/clusters.postgresql.cnpg.io --timeout=60s || true
+	@echo "Waiting until CloudNativePG Cluster custom resource is accepted by API server..."
+	@until kubectl get clusters.postgresql.cnpg.io --all-namespaces >/dev/null 2>&1; do \
+		echo "  Cluster CR still not usable, waiting..."; \
+		sleep 2; \
+	done
+	@echo "✅ CloudNativePG operator deployment completed and CRDs are ready."
 .PHONY: postgres-operator-delete
 postgres-operator-delete: _env-check ## Delete CloudNativePG operator with its namespace
 	@echo "Deleting CloudNativePG operator from 'cnpg-system' namespace..."
@@ -903,13 +909,20 @@ MONGO_PRODUCT_USER_PWD ?= mongoProductUserPwd
 .PHONY: mongodb-operator-install
 mongodb-operator-install: _env-check ## Install MongoDB Community Operator
 	@kubectl get namespace "$(DATA_NS)" >/dev/null 2>&1 || kubectl create namespace "$(DATA_NS)"
-	@helm repo add mongodb https://mongodb.github.io/helm-charts
+	@helm repo add mongodb https://mongodb.github.io/helm-charts || true
 	@helm repo update
 	@echo "Installing MongoDB operator v$(MONGODB_OPERATOR_VERSION) into $(DATA_NS) namespace..."
 	@helm upgrade --install mongodb-operator mongodb/community-operator \
-		--version "$(MONGODB_OPERATOR_VERSION)" \
-		--namespace "$(DATA_NS)"
-	@echo "✅ MongoDB operator installation initiated."
+	    --version "$(MONGODB_OPERATOR_VERSION)" \
+	    --namespace "$(DATA_NS)"
+	@echo "Waiting for MongoDBCommunity CRD to be registered..."
+	@kubectl wait --for=condition=Established crd/mongodbcommunity.mongodb.com --timeout=60s || true
+	@echo "Waiting until MongoDBCommunity custom resource is accepted by API server..."
+	@until kubectl get mongodbcommunity.mongodb.com --all-namespaces >/dev/null 2>&1; do \
+		echo "  MongoDBCommunity CR still not usable, waiting..."; \
+		sleep 2; \
+	done
+	@echo "✅ MongoDB operator deployment completed and CRDs are ready."
 
 .PHONY: mongodb-operator-uninstall
 mongodb-operator-uninstall: _env-check ## Delete MongoDB Community Operator
@@ -1285,10 +1298,9 @@ cluster-infra-deploy: _env-check ## Deploy all infra apps (except monitoring sta
 	@if [ "$(ENV_NAME)" = "local-dev" ]; then \
 		$(MAKE) minio-operator-deploy; \
 	fi
-	$(MAKE) postgres-operator-deploy & \
-	$(MAKE) mongodb-operator-install & \
-	$(MAKE) kafka-strimzi-operator-install & wait
-	@echo "⏳ Waiting 30s for infra operators..." && sleep 30
+	$(MAKE) postgres-operator-deploy
+	$(MAKE) mongodb-operator-install
+	$(MAKE) kafka-strimzi-operator-install
 
 	# Elasticsearch
 	@if [ "$(ENV_NAME)" = "local-dev" ]; then \

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -1287,15 +1287,15 @@ cluster-qa-monitoring-deploy: _env-check _data-ns-check ## Deploy monitoring sta
 	$(MAKE) minio-svc-user-secret-create SVC_NAME=tempo COPY_SECRET_NS=$(MONITORING_NS)
 	$(MAKE) minio-svc-user-with-policy-create SVC_NAME=tempo POLICY_FILE=apps/infra/tempo/minio/s3-policy-tempo-traces.json
 
-	# Grafana Loki,Tempo and Alloy
-	$(MAKE) loki-install
-	$(MAKE) tempo-install
-	$(MAKE) alloy-install
-
 	# Zipkin (requires Elasticsearch)
 	$(MAKE) zipkin-es-user-secret-create
 	$(MAKE) zipkin-es-user-create
 	$(MAKE) zipkin-install
+
+	# Grafana Loki,Tempo and Alloy
+	$(MAKE) loki-install
+	$(MAKE) tempo-install
+	$(MAKE) alloy-install
 
 	@echo "✅ QA cluster monitoring stack deployed!"
 

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -1259,11 +1259,11 @@ cluster-qa-monitoring-deploy: _env-check _data-ns-check ## Deploy monitoring sta
 		exit 1; \
 	fi
 
-	# Prometheus & Grafana stack
-	$(MAKE) prometheus-stack-install
-
 	# Elasticsearch
 	$(MAKE) es-deploy
+
+	# Prometheus & Grafana stack
+	$(MAKE) prometheus-stack-install
 
     # Monitoring operator
 	$(MAKE) minio-operator-deploy
@@ -1287,15 +1287,15 @@ cluster-qa-monitoring-deploy: _env-check _data-ns-check ## Deploy monitoring sta
 	$(MAKE) minio-svc-user-secret-create SVC_NAME=tempo COPY_SECRET_NS=$(MONITORING_NS)
 	$(MAKE) minio-svc-user-with-policy-create SVC_NAME=tempo POLICY_FILE=apps/infra/tempo/minio/s3-policy-tempo-traces.json
 
-	# Zipkin (requires Elasticsearch)
-	$(MAKE) zipkin-es-user-secret-create
-	$(MAKE) zipkin-es-user-create
-	$(MAKE) zipkin-install
-
 	# Grafana Loki,Tempo and Alloy
 	$(MAKE) loki-install
 	$(MAKE) tempo-install
 	$(MAKE) alloy-install
+
+	# Zipkin (requires Elasticsearch)
+	$(MAKE) zipkin-es-user-secret-create
+	$(MAKE) zipkin-es-user-create
+	$(MAKE) zipkin-install
 
 	@echo "✅ QA cluster monitoring stack deployed!"
 

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -299,16 +299,19 @@ KUBE_PROMETHEUS_STACK_VERSION := 79.3.0
 prometheus-operator-crds-install: _monitoring-ns-check
 	@helm repo add prometheus-community https://prometheus-community.github.io/helm-charts || true
 	@helm repo update
-	@echo "Installing Prometheus Operator CRDs..."
+	@echo "Installing Prometheus Operator CRDs into $(MONITORING_NS) namespace..."
 	@helm upgrade --install prometheus-operator-crds prometheus-community/prometheus-operator-crds \
 		--namespace $(MONITORING_NS) --create-namespace
 	@echo "Waiting for monitoring.coreos.com CRDs to be registered..."
-	@kubectl wait --for=condition=Established crd/alertmanagers.monitoring.coreos.com --timeout=60s || true
+	@kubectl wait --for=condition=Established crd/alertmanagers.monitoring.coreos.com --timeout=60s
+	@echo "Waiting until Alertmanager custom resource is accepted by API server..."
+	@until kubectl get alertmanagers.monitoring.coreos.com --all-namespaces >/dev/null 2>&1; do \
+		echo "  Alertmanager CR still not usable, waiting..."; \
+		sleep 2; \
+	done
 
 .PHONY: prometheus-stack-install
 prometheus-stack-install: prometheus-operator-crds-install ## Install Kube Prometheus Stack (Prometheus, Grafana, Alert Manager) in QA
-	@helm repo add prometheus-community https://prometheus-community.github.io/helm-charts || true
-	@helm repo update
 	@echo "Installing Kube Prometheus Stack using Helm chart v$(KUBE_PROMETHEUS_STACK_VERSION) into $(MONITORING_NS) namespace..."
 	@helm upgrade --install "$(ENV_NAME)"-prometheus prometheus-community/kube-prometheus-stack \
 		--version "$(KUBE_PROMETHEUS_STACK_VERSION)" \
@@ -1227,13 +1230,14 @@ cluster-qa-monitoring-deploy: _env-check _data-ns-check ## Deploy monitoring sta
 		exit 1; \
 	fi
 
+	# Prometheus & Grafana stack
+	$(MAKE) prometheus-stack-install
+
 	# Elasticsearch
 	$(MAKE) es-operator-deploy
 	@echo "⏳ Waiting 30s for Elastic operator..." && sleep 30
 	$(MAKE) es-deploy
 
-	# Prometheus & Grafana stack
-	$(MAKE) prometheus-stack-install
 
     # Monitoring operator
 	$(MAKE) minio-operator-deploy

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -906,13 +906,14 @@ MONGODB_OPERATOR_VERSION := 0.13.0
 MONGO_ROOT_USER_PWD ?= mongoRootUserPwd
 MONGO_PRODUCT_USER_PWD ?= mongoProductUserPwd
 
-.PHONY: mongodb-crds-install
-mongodb-crds-install: _env-check ## Install MongoDB Community Operator CRDs
+.PHONY: mongodb-operator-install
+mongodb-operator-install: _env-check ## Install MongoDB Community Operator
 	@kubectl get namespace "$(DATA_NS)" >/dev/null 2>&1 || kubectl create namespace "$(DATA_NS)"
 	@helm repo add mongodb https://mongodb.github.io/helm-charts || true
 	@helm repo update
-	@echo "Installing MongoDB Community Operator CRDs into $(DATA_NS) namespace..."
-	@helm upgrade --install mongodb-operator-crds mongodb/community-operator-crds \
+	@echo "Installing MongoDB operator v$(MONGODB_OPERATOR_VERSION) into $(DATA_NS) namespace..."
+	@helm upgrade --install mongodb-operator mongodb/community-operator \
+	    --version "$(MONGODB_OPERATOR_VERSION)" \
 	    --namespace "$(DATA_NS)"
 	@echo "Waiting for MongoDBCommunity CRD to be registered..."
 	@kubectl wait --for=condition=Established crd/mongodbcommunity.mongodbcommunity.mongodb.com --timeout=60s || true
@@ -921,15 +922,7 @@ mongodb-crds-install: _env-check ## Install MongoDB Community Operator CRDs
 		echo "  MongoDBCommunity CR still not usable, waiting..."; \
 		sleep 2; \
 	done
-	@echo "✅ MongoDB Community Operator CRDs are installed and ready."
-
-.PHONY: mongodb-operator-install
-mongodb-operator-install: mongodb-crds-install ## Install MongoDB Community Operator
-	@echo "Installing MongoDB operator v$(MONGODB_OPERATOR_VERSION) into $(DATA_NS) namespace..."
-	@helm upgrade --install mongodb-operator mongodb/community-operator \
-	   --version "$(MONGODB_OPERATOR_VERSION)" \
-	   --namespace "$(DATA_NS)"
-	@echo "✅ MongoDB operator deployment initiated."
+	@echo "✅ MongoDB operator deployment completed and MongoDBCommunity CRD is ready."
 
 .PHONY: mongodb-operator-uninstall
 mongodb-operator-uninstall: _env-check ## Delete MongoDB Community Operator

--- a/k8s/base-cluster-how-tos.md
+++ b/k8s/base-cluster-how-tos.md
@@ -99,7 +99,7 @@ to create and manage the QA cluster based on [K3s](https://www.rancher.com/produ
     | NAME | STATE | IPV4 | IPV6 | TYPE | SNAPSHOTS |
     +------+-------+------+------+------+-----------+
     ```
-- `make qa-nodes-create`
+- `make qa-nodes-create` or `MASTER_ONLY=true make qa-nodes-create` with only the master node
 - `lxc list`
     ```bash
     +------------+---------+------------------------+-------------------------------------------------+-----------------+-----------+

--- a/k8s/bootstrap/Makefile
+++ b/k8s/bootstrap/Makefile
@@ -66,8 +66,8 @@ local-dev-resume: ## Resume (start) the local dev Kind cluster
 qa-create: qa-nodes-create qa-cluster-create qa-cluster-pull-kubeconfig ## Create and configure QA cluster
 
 .PHONY: qa-cluster-create
-qa-cluster-create: ## Set up multi-node Rancher K3s QA cluster
-	bash qa/scripts/qa-cluster-create.sh
+qa-cluster-create: ## Set up Rancher K3s QA cluster (master + 2 workers by default; master only if MASTER_ONLY=true)
+	MASTER_ONLY=$(MASTER_ONLY) bash qa/scripts/qa-cluster-create.sh
 
 .PHONY: qa-cluster-pull-kubeconfig
 qa-cluster-pull-kubeconfig: ## Pull kubeconfig from QA cluster
@@ -78,8 +78,8 @@ qa-cluster-pull-kubeconfig: ## Pull kubeconfig from QA cluster
 # Targets for creating and managing the LXD virtual machines for QA cluster
 ################################################################################
 .PHONY: qa-nodes-create
-qa-nodes-create: ## Create three LXD VMs (master and two workers) for QA cluster
-	bash qa/scripts/qa-nodes-create.sh
+qa-nodes-create: ## Create LXD VMs for QA cluster (master + 2 workers by default; master only if MASTER_ONLY=true)
+	MASTER_ONLY=$(MASTER_ONLY) bash qa/scripts/qa-nodes-create.sh
 
 .PHONY: qa-nodes-suspend
 qa-nodes-suspend: ## Suspend (pause) all QA LXD VMs

--- a/k8s/bootstrap/qa/scripts/qa-cluster-create.sh
+++ b/k8s/bootstrap/qa/scripts/qa-cluster-create.sh
@@ -3,69 +3,99 @@
 set -euo pipefail
 
 QA_CLUSTER_NAME="qa-insurance-hub"
+MASTER_NODE="qa-master"
+WORKER_NODES=("qa-worker1" "qa-worker2")
 
-echo "Waiting for qa-master to get a valid IPv4 address..."
+MASTER_ONLY="${MASTER_ONLY:-false}"
+
+echo "MASTER_ONLY=$MASTER_ONLY"
+
+echo "Waiting for $MASTER_NODE to get a valid IPv4 address..."
 MASTER_IP=""
 for i in {1..20}; do
-  MASTER_IP=$(lxc list qa-master -c 4 --format json | \
+  MASTER_IP=$(lxc list "$MASTER_NODE" -c 4 --format json | \
     jq -r '.[0].state.network | to_entries | map(.value.addresses // []) | add | map(select(.family=="inet" and .scope=="global" and .address != "127.0.0.1")) | .[0].address')
   [ -n "$MASTER_IP" ] && break
-  echo "Waiting for qa-master IP address..."
+  echo "Waiting for $MASTER_NODE IP address..."
   sleep 5
 done
 if [ -z "$MASTER_IP" ]; then
-  echo "Failed to get qa-master IP address!" >&2
+  echo "Failed to get $MASTER_NODE IP address!" >&2
   exit 1
 fi
 echo "Master IP: $MASTER_IP"
 
-MASTER_IFACE=$(lxc list qa-master -c 4 --format json | \
+MASTER_IFACE=$(lxc list "$MASTER_NODE" -c 4 --format json | \
   jq -r '.[0].state.network | to_entries[] | select(.value.addresses[].family == "inet" and .value.addresses[].scope == "global") | .key')
 if [ -z "$MASTER_IFACE" ]; then
-  echo "Failed to get qa-master network interface!" >&2
+  echo "Failed to get $MASTER_NODE network interface!" >&2
   exit 1
 fi
 echo "Master Interface: $MASTER_IFACE"
 
-echo "Setting up Rancher k3s cluster on qa-master node..."
+echo "Setting up Rancher k3s cluster on $MASTER_NODE node..."
 
-# Install k3s server, using the host's default nftables mode.
-lxc exec qa-master -- bash -c "curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC='server --disable=traefik --write-kubeconfig-mode 644 --tls-san=$MASTER_IP --flannel-iface=$MASTER_IFACE' sh -"
+lxc exec "$MASTER_NODE" -- bash -c "curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC='server --disable=traefik --write-kubeconfig-mode 644 --tls-san=$MASTER_IP --flannel-iface=$MASTER_IFACE' sh -"
 
-echo "Waiting for k3s server on qa-master to become active..."
-lxc exec qa-master -- bash -c 'for i in {1..20}; do systemctl is-active k3s && break || (echo Waiting for k3s server...; sleep 5); done'
+echo "Waiting for k3s server on $MASTER_NODE to become active..."
+lxc exec "$MASTER_NODE" -- bash -c 'for i in {1..20}; do systemctl is-active k3s && break || (echo Waiting for k3s server...; sleep 5); done'
 
-TOKEN=$(lxc exec qa-master -- sudo cat /var/lib/rancher/k3s/server/node-token)
-echo "Node Token: $TOKEN"
+if [[ "$MASTER_ONLY" != "true" ]]; then
+  TOKEN=$(lxc exec "$MASTER_NODE" -- sudo cat /var/lib/rancher/k3s/server/node-token)
+  echo "Node Token: $TOKEN"
 
-for WORKER in qa-worker1 qa-worker2; do
-  echo "Installing k3s agent on $WORKER..."
-  # The agent will also use the host's nftables mode.
-  lxc exec "$WORKER" -- bash -c "curl -sfL https://get.k3s.io | K3S_URL=https://$MASTER_IP:6443 K3S_TOKEN=$TOKEN INSTALL_K3S_EXEC='agent --flannel-iface=$MASTER_IFACE' sh -"
-done
+  for WORKER in "${WORKER_NODES[@]}"; do
+    echo "Installing k3s agent on $WORKER..."
+    lxc exec "$WORKER" -- bash -c "curl -sfL https://get.k3s.io | K3S_URL=https://$MASTER_IP:6443 K3S_TOKEN=$TOKEN INSTALL_K3S_EXEC='agent --flannel-iface=$MASTER_IFACE' sh -"
+  done
+else
+  echo "MASTER_ONLY=true, skipping worker node installation."
+fi
 
-echo "Waiting for all nodes to register in the cluster..."
-lxc exec qa-master -- bash -c 'for i in {1..20}; do kubectl get nodes &>/dev/null && break || (echo Waiting for nodes...; sleep 5); done'
+echo "Waiting for nodes to register in the cluster..."
+lxc exec "$MASTER_NODE" -- bash -c 'for i in {1..20}; do kubectl get nodes &>/dev/null && break || (echo Waiting for nodes...; sleep 5); done'
 
-echo "Waiting for qa-master to generate kubeconfig..."
+if [[ "$MASTER_ONLY" == "true" ]]; then
+  echo "Waiting for master node to appear in the cluster..."
+  lxc exec "$MASTER_NODE" -- bash -c '
+    for i in {1..24}; do
+      COUNT=$(kubectl get nodes --no-headers 2>/dev/null | wc -l || echo 0)
+      [ "$COUNT" -ge 1 ] && echo "Master node is registered." && break
+      echo "Waiting for master node..."
+      sleep 5
+    done
+  '
+else
+  echo "Waiting for all nodes to appear in the cluster..."
+  lxc exec "$MASTER_NODE" -- bash -c '
+    for i in {1..24}; do
+      COUNT=$(kubectl get nodes --no-headers 2>/dev/null | wc -l || echo 0)
+      [ "$COUNT" -ge 3 ] && echo "All nodes are registered." && break
+      echo "Waiting for all nodes..."
+      sleep 5
+    done
+  '
+fi
+
+echo "Waiting for $MASTER_NODE to generate kubeconfig..."
 for i in {1..24}; do
-  if lxc exec qa-master -- bash -c "test -s /etc/rancher/k3s/k3s.yaml"; then break; fi
+  if lxc exec "$MASTER_NODE" -- bash -c "test -s /etc/rancher/k3s/k3s.yaml"; then break; fi
   echo "Waiting for /etc/rancher/k3s/k3s.yaml to be ready..."
   sleep 5
 done
 
 echo "Waiting for CoreDNS addon to become ready..."
-lxc exec qa-master -- bash -c '
+lxc exec "$MASTER_NODE" -- bash -c '
   for i in {1..24}; do
     READY=$(kubectl -n kube-system get deploy coredns -o jsonpath="{.status.readyReplicas}" 2>/dev/null || echo 0);
-    [ "$READY" != "" ] && [ $READY -ge 1 ] && echo "CoreDNS is Ready." && break;
+    [ "$READY" != "" ] && [ "$READY" -ge 1 ] && echo "CoreDNS is Ready." && break;
     echo "Waiting for CoreDNS to be Ready...";
     sleep 5;
   done;
 '
 
 echo "Applying custom CoreDNS configuration to fix DNS resolution..."
-lxc exec qa-master -- kubectl apply -f - <<'EOF'
+lxc exec "$MASTER_NODE" -- kubectl apply -f - <<'EOF'
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -76,4 +106,8 @@ data:
     rewrite name kubernetes.default kubernetes.default.svc.cluster.local
 EOF
 
-echo "QA cluster '$QA_CLUSTER_NAME' has been successfully created!"
+if [[ "$MASTER_ONLY" == "true" ]]; then
+  echo "QA cluster '$QA_CLUSTER_NAME' has been successfully created with master node only."
+else
+  echo "QA cluster '$QA_CLUSTER_NAME' has been successfully created with master and 2 worker nodes."
+fi

--- a/k8s/bootstrap/qa/scripts/qa-nodes-create.sh
+++ b/k8s/bootstrap/qa/scripts/qa-nodes-create.sh
@@ -4,7 +4,15 @@ set -euo pipefail
 
 NODES_MASTER="qa-master"
 NODES_WORKER="qa-worker1 qa-worker2"
-NODES_ALL="$NODES_MASTER $NODES_WORKER"
+
+# If MASTER_ONLY=true, create only the master node; otherwise master + 2 workers
+if [[ "${MASTER_ONLY:-}" == "true" ]]; then
+    echo "MASTER_ONLY is true; only creating master node: $NODES_MASTER"
+    NODES_ALL="$NODES_MASTER"
+else
+    echo "MASTER_ONLY not set or not true; creating master and worker nodes: $NODES_MASTER $NODES_WORKER"
+    NODES_ALL="$NODES_MASTER $NODES_WORKER"
+fi
 
 for NODE in $NODES_ALL; do
     if ! lxc info "$NODE" &>/dev/null; then

--- a/k8s/cluster-apps-how-tos.md
+++ b/k8s/cluster-apps-how-tos.md
@@ -37,11 +37,11 @@ and "Insurance Hub" infrastructure and services.
 
 - **Optional** `make legacy-all-build`
 - `cd k8s`
-- **QA**: `make cluster-qa-monitoring-deploy`
+- **QA**: `make cluster-qa-monitoring-deploy`, then ensure that all pods are running: `kgp --all-namespaces | grep "0/"`
 - **QA**: `make -C bootstrap qa-nodes-snapshot QA_SNAPSHOT_NAME=qa-cluster-monitoring-deploy-<iso-date>`
-- `make cluster-infra-deploy`
+- `make cluster-infra-deploy`, then ensure that all pods are running: `kgp --all-namespaces | grep "0/"`
 - **QA**: `make -C bootstrap qa-nodes-snapshot QA_SNAPSHOT_NAME=qa-cluster-infra-deploy-<iso-date>` 
-- `make cluster-svc-deploy`
+- `make cluster-svc-deploy`, then ensure that all pods are running: `kgp --all-namespaces | grep "0/"`
 
 ## Step-by-Step Deployment
 

--- a/k8s/cluster-apps-how-tos.md
+++ b/k8s/cluster-apps-how-tos.md
@@ -160,7 +160,6 @@ For verification, see [Alloy runbook](tests/infra/verify-alloy-traces/verify-all
 
 #### Elasticsearch
 
-- `make es-operator-deploy`
 - `make es-deploy`
 - `make es-status`
 - **QA**: `make es-exporter-deploy`

--- a/k8s/tests/infra/verify-alloy-traces/verify-alloy-traces.md
+++ b/k8s/tests/infra/verify-alloy-traces/verify-alloy-traces.md
@@ -50,18 +50,19 @@ services (Zipkin protocol), and dual-exports them to both Tempo and Zipkin.
    In another terminal:
 
    ```shell
-   TRACE_ID=$(python3 -c 'import secrets; print(secrets.token_hex(16))')
-   SPAN_ID=$(python3 -c 'import secrets; print(secrets.token_hex(8))')
-   TS=$(python3 -c 'import time; print(int(time.time()*1_000_000_000))')
-
-   curl -s http://localhost:4318/v1/traces \
-     -H 'Content-Type: application/json' \
-     -d '{"resourceSpans":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"alloy-dual-smoke"}}]},"scopeSpans":[{"scope":{"name":"smoke"},"spans":[{"traceId":"'"$TRACE_ID"'","spanId":"'"$SPAN_ID"'","name":"alloy-dual-smoke-span","kind":"SPAN_KIND_INTERNAL","startTimeUnixNano":"'"$TS"'","endTimeUnixNano":"'"$((TS+5000000))"'"}]}]}]}'
-
-   echo "TRACE_ID=$TRACE_ID"
+   TRACE_ID=$(python3 -c 'import secrets; print(secrets.token_hex(16))'); \
+     SPAN_ID=$(python3 -c 'import secrets; print(secrets.token_hex(8))'); \
+     TS=$(python3 -c 'import time; print(int(time.time()*1_000_000_000))'); \
+     curl -s http://localhost:4318/v1/traces \
+       -H 'Content-Type: application/json' \
+       -d '{"resourceSpans":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"alloy-dual-smoke"}}]},"scopeSpans":[{"scope":{"name":"smoke"},"spans":[{"traceId":"'"$TRACE_ID"'","spanId":"'"$SPAN_ID"'","name":"alloy-dual-smoke-span","kind":"SPAN_KIND_INTERNAL","startTimeUnixNano":"'"$TS"'","endTimeUnixNano":"'"$((TS+5000000))"'"}]}]}]}'; \
+     echo "TRACE_ID=$TRACE_ID"
    ```
 
-   **Expected**: API responds with `{"partialSuccess":{}}` or empty success response.
+   **Expected**: 
+   ```json
+   {"partialSuccess":{}}
+   ```
 
 5. **Verify Alloy exporter metrics for traces**
 

--- a/k8s/tests/infra/verify-tempo-traces/verify-tempo-traces.md
+++ b/k8s/tests/infra/verify-tempo-traces/verify-tempo-traces.md
@@ -49,15 +49,35 @@ Tempo MinIO bucket, and is queryable via API and Grafana.
 4. **Push and verify a synthetic trace**
 
    ```shell
+   # Push
    TRACE_ID=$(python3 -c 'import secrets; print(secrets.token_hex(16))'); \
      SPAN_ID=$(python3 -c 'import secrets; print(secrets.token_hex(8))'); \
      TS=$(python3 -c 'import time; print(int(time.time()*1_000_000))'); \
      curl -s http://localhost:4318/v1/traces -H 'Content-Type: application/json' -d '{"resourceSpans":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"tempo-smoke"}}]},"scopeSpans":[{"scope":{"name":"smoke"},"spans":[{"traceId":"'"$TRACE_ID"'","spanId":"'"$SPAN_ID"'","name":"tempo-smoke-test","kind":"SPAN_KIND_INTERNAL","startTimeUnixNano":"'"$((TS*1000))"'","endTimeUnixNano":"'"$((TS*1000+5000000))"'"}]}]}]}'   # Verify trace is retrievable by trace ID
    sleep 10
+   ```
+
+   **Expected**: 
+   ```json
+   {"partialSuccess":{}}
+   ```
+
+   ```shell
+   # Verify
    curl -s "http://localhost:3200/api/traces/$TRACE_ID" | jq '.batches[0].resource.attributes'
    ```
 
-   **Expected**: `{"partialSuccess":{}}`
+   **Expected**:
+   ```json
+   [
+     {
+       "key": "service.name",
+       "value": {
+         "stringValue": "tempo-smoke"
+       }
+     }
+   ]
+   ```
 
 5. **Verify bucket object presence in MinIO**
 

--- a/k8s/tests/infra/verify-tempo-traces/verify-tempo-traces.md
+++ b/k8s/tests/infra/verify-tempo-traces/verify-tempo-traces.md
@@ -53,8 +53,8 @@ Tempo MinIO bucket, and is queryable via API and Grafana.
    TRACE_ID=$(python3 -c 'import secrets; print(secrets.token_hex(16))'); \
      SPAN_ID=$(python3 -c 'import secrets; print(secrets.token_hex(8))'); \
      TS=$(python3 -c 'import time; print(int(time.time()*1_000_000))'); \
-     curl -s http://localhost:4318/v1/traces -H 'Content-Type: application/json' -d '{"resourceSpans":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"tempo-smoke"}}]},"scopeSpans":[{"scope":{"name":"smoke"},"spans":[{"traceId":"'"$TRACE_ID"'","spanId":"'"$SPAN_ID"'","name":"tempo-smoke-test","kind":"SPAN_KIND_INTERNAL","startTimeUnixNano":"'"$((TS*1000))"'","endTimeUnixNano":"'"$((TS*1000+5000000))"'"}]}]}]}'   # Verify trace is retrievable by trace ID
-   sleep 10
+     curl -s http://localhost:4318/v1/traces -H 'Content-Type: application/json' -d '{"resourceSpans":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"tempo-smoke"}}]},"scopeSpans":[{"scope":{"name":"smoke"},"spans":[{"traceId":"'"$TRACE_ID"'","spanId":"'"$SPAN_ID"'","name":"tempo-smoke-test","kind":"SPAN_KIND_INTERNAL","startTimeUnixNano":"'"$((TS*1000))"'","endTimeUnixNano":"'"$((TS*1000+5000000))"'"}]}]}]}'; \
+     echo "Sleeping for 10s..." && sleep 10
    ```
 
    **Expected**: 


### PR DESCRIPTION
### Summary

This pull request improves the reliability and flexibility of the QA K3s cluster provisioning process. It addresses race conditions in which Kubernetes Operators were often considered "ready" before their Custom Resource Definitions (CRDs) were fully registered with the API server.

The implementation aligns with the [Phase 2: [4] Improve provisioning of QA K8s cluster](https://github.com/users/igor-baiborodine/projects/8/views/1?pane=issue&itemId=186411988&issue=igor-baiborodine%7Cinsurance-hub%7C86) requirements, namely deterministic "wait-until-ready" logic for all infrastructure operators (ECK, CloudNativePG, Strimzi, MinIO, MongoDB) and the introduction of a `MASTER_ONLY` mode for lightweight cluster deployments. These changes ensure a more stable foundation for the Phase 2 observability stack and future service migrations.

### Key Changes

- **Deterministic Operator Readiness**
    - Refactored Makefile targets for `postgres-operator`, `es-operator`, `kafka-strimzi-operator`, `minio-operator`, and `mongodb-operator`.
    - Replaced fixed `sleep` commands with robust `kubectl wait --for=condition=Established` for CRDs.
    - Added polling loops (`until` blocks) to ensure Custom Resources (e.g., `Alertmanager`, `Cluster`, `Elasticsearch`, `Kafka`) are fully accepted by the API server before proceeding.

- **Flexible Node Configuration (MASTER_ONLY mode)**
    - Updated `k8s/bootstrap/qa/scripts/qa-nodes-create.sh` and `qa-cluster-create.sh` to support the `MASTER_ONLY` environment variable.
    - When enabled, the cluster provisioning skips worker node creation and agent installation, significantly reducing resource overhead for master-only testing environments.
    - Updated `k8s/bootstrap/Makefile` to pass the `MASTER_ONLY` flag to underlying scripts.

- **Kube Prometheus Stack Hardening**
    - Extracted CRD installation into a dedicated `prometheus-operator-crds-install` target.
    - Configured `prometheus-stack-install` to depend on CRD registration, preventing Helm installation failures caused by missing Monitoring CRDs.

- **Deployment Workflow Optimization**
    - Refactored `cluster-qa-monitoring-deploy` to follow a strict dependency order: Operators -> MinIO Tenants -> Monitoring Backend (Loki, Tempo, Alloy) -> Zipkin.
    - Consolidated Elasticsearch deployment by moving operator deployment logic directly into the `es-deploy` flow.
    - Renamed "infra tenants" to "monitoring tenants" in MinIO setup to better reflect their purpose.

- **Environment Guardrails**
    - Updated `cluster-svc-deploy` to intelligently choose between `svc-load-delete-deploy` (Kind-specific) and standard `svc-deploy` based on the `ENV_NAME`.
    - Enhanced status reporting in `cluster-svc-deploy` to include `auth` and other critical microservices.

- **Documentation & Tests**
    - Updated `k8s/base-cluster-how-tos.md` with instructions for master-only node creation.
    - Improved smoke test scripts for Alloy and Tempo with better command formatting and explicit status feedback.

### Testing Notes

- **Provision a standard QA cluster:**
```
cd k8s/bootstrap
make qa-create
```


- **Provision a master-only QA cluster:**
```
cd k8s/bootstrap
MASTER_ONLY=true make qa-create
```


- **Verify operator readiness logic:**
    - Run `make postgres-operator-deploy` or `make kafka-strimzi-operator-install`.
    - Observe the "Waiting for... CRD to be registered" and polling loops in the console output.

- **Deploy the full monitoring stack:**
```
cd k8s
make cluster-qa-monitoring-deploy
```

- Confirm that the stack installs without "CRD not found" errors, even on a fresh cluster.