### PR TITLE
feat: issue-101 capture product service behaviour

### DIFF
--- a/.github/workflows/legacy-pr-api-svc.yml
+++ b/.github/workflows/legacy-pr-api-svc.yml
@@ -7,6 +7,10 @@ on:
     paths:
       - 'legacy/**'
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   validate-and-build:
     runs-on: ubuntu-latest
@@ -54,11 +58,16 @@ jobs:
           java-version: '14'
           distribution: 'zulu'
           cache: 'maven'
+          server-id: github
+          settings-path: ${{ github.workspace }}
 
       - name: Build module
         if: steps.detect.outputs.module != ''
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           MODULE_PATH="${{ steps.detect.outputs.module_path }}"
           # Only package without publishing or testing
-          mvn -f "$MODULE_PATH/pom.xml" clean package -DskipTests
+          mvn -f "$MODULE_PATH/pom.xml" clean package -DskipTests \
+            -s "${{ github.workspace }}/settings.xml"

--- a/ai/rules/java-rules.md
+++ b/ai/rules/java-rules.md
@@ -16,6 +16,8 @@ These rules are intentionally minimal until service-specific Java conventions ar
 When writing or updating JUnit 5 unit or integration tests, prefer an explicit given-when-then
 structure over helper-driven BDD wrappers.
 
+- Name classes with unit tests following `<ClassName>Test` pattern.
+- Name classes with integration tests following `<ClassName>IT` pattern.
 - Group tests for a specific production method inside a JUnit 5 `@Nested` class.
 - Name the instance under test `classUnderTest`.
 - Use `happyPath` for the main successful case.

--- a/ai/rules/java-rules.md
+++ b/ai/rules/java-rules.md
@@ -8,3 +8,28 @@ These rules are intentionally minimal until service-specific Java conventions ar
 - Keep DTO validation explicit and close to the contract boundary.
 - Add or update tests near the changed production code when behavior changes.
 - Do not introduce broad framework upgrades or dependency changes as part of feature work unless the ticket requires them.
+
+## Tests 
+
+### Structure
+
+When writing or updating JUnit 5 unit or integration tests, prefer an explicit given-when-then
+structure over helper-driven BDD wrappers.
+
+- Group tests for a specific production method inside a JUnit 5 `@Nested` class.
+- Name the instance under test `classUnderTest`.
+- Use `happyPath` for the main successful case.
+- Use `given<preconditions_and_inputs>_then<expected_results>` for other scenarios.
+- Structure each test method with explicit `// given`, `// when`, and `// then` comments.
+- Keep the `when` block limited to the method invocation under test.
+- Store the invocation result in a variable named `result`.
+
+### Assertions
+
+- Prefer AssertJ assertions in Java tests for readable, fluent assertion chains.
+
+### Fixtures
+
+- Create test fixtures with Easy Random when randomized object graphs or broad sample data reduce
+  test setup noise.
+- Prefer Easy Random over ad hoc object builders for repeated fixture creation in Java tests.

--- a/legacy/product-service/pom.xml
+++ b/legacy/product-service/pom.xml
@@ -132,6 +132,21 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micronaut.test</groupId>
+            <artifactId>micronaut-test-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>3.24.2</version>

--- a/legacy/product-service/pom.xml
+++ b/legacy/product-service/pom.xml
@@ -126,12 +126,6 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/legacy/product-service/pom.xml
+++ b/legacy/product-service/pom.xml
@@ -131,6 +131,18 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.24.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jeasy</groupId>
+            <artifactId>easy-random-core</artifactId>
+            <version>5.0.0</version>
+            <scope>test</scope>
+        </dependency>
         <!-- TESTS -->
 
         <!-- INTERNAL -->

--- a/legacy/product-service/src/test/java/pl/altkom/asc/lab/micronaut/poc/product/service/infrastructure/adapters/db/InMemoryProductsRepository.java
+++ b/legacy/product-service/src/test/java/pl/altkom/asc/lab/micronaut/poc/product/service/infrastructure/adapters/db/InMemoryProductsRepository.java
@@ -1,0 +1,40 @@
+package pl.altkom.asc.lab.micronaut.poc.product.service.infrastructure.adapters.db;
+
+import io.micronaut.context.annotation.Replaces;
+import io.reactivex.Maybe;
+import io.reactivex.Single;
+import pl.altkom.asc.lab.micronaut.poc.product.service.domain.Product;
+
+import javax.inject.Singleton;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Singleton
+@Replaces(ProductsRepository.class)
+public class InMemoryProductsRepository extends ProductsRepository {
+
+    private final Map<String, Product> productsByCode = new LinkedHashMap<>();
+
+    public InMemoryProductsRepository() {
+        super(null);
+    }
+
+    @Override
+    public Single<Product> add(Product product) {
+        productsByCode.put(product.getCode(), product);
+        return Single.just(product);
+    }
+
+    @Override
+    public Single<List<Product>> findAll() {
+        return Single.just(new ArrayList<>(productsByCode.values()));
+    }
+
+    @Override
+    public Maybe<Product> findOne(String productCode) {
+        Product product = productsByCode.get(productCode);
+        return product == null ? Maybe.empty() : Maybe.just(product);
+    }
+}

--- a/legacy/product-service/src/test/java/pl/altkom/asc/lab/micronaut/poc/product/service/infrastructure/adapters/web/ProductsControllerIT.java
+++ b/legacy/product-service/src/test/java/pl/altkom/asc/lab/micronaut/poc/product/service/infrastructure/adapters/web/ProductsControllerIT.java
@@ -94,4 +94,26 @@ public class ProductsControllerIT {
                     });
         }
     }
+
+    @Nested
+    public class GetByCode {
+
+        @Test
+        public void happyPath() {
+            // given
+            String productCode = "TRI";
+
+            // when
+            ProductDto result = classUnderTest.get(productCode);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getCode()).isEqualTo("TRI");
+            assertThat(result.getName()).isEqualTo("Safe Traveller");
+            assertThat(result.getCovers()).hasSize(3);
+            assertThat(result.getQuestions()).hasSize(3);
+            assertThat(result.getMaxNumberOfInsured()).isEqualTo(10);
+            assertThat(result.getIcon()).isEqualTo("plane");
+        }
+    }
 }

--- a/legacy/product-service/src/test/java/pl/altkom/asc/lab/micronaut/poc/product/service/infrastructure/adapters/web/ProductsControllerIT.java
+++ b/legacy/product-service/src/test/java/pl/altkom/asc/lab/micronaut/poc/product/service/infrastructure/adapters/web/ProductsControllerIT.java
@@ -1,0 +1,97 @@
+package pl.altkom.asc.lab.micronaut.poc.product.service.infrastructure.adapters.web;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.runtime.server.EmbeddedServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import pl.altkom.asc.lab.micronaut.poc.product.service.api.v1.ProductDto;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ProductsControllerIT {
+
+    private ProductsTestClient classUnderTest;
+    private EmbeddedServer server;
+
+    @BeforeAll
+    void setup() {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("micronaut.environments", "test");
+        server = ApplicationContext.run(EmbeddedServer.class, properties);
+        classUnderTest = server.getApplicationContext().createBean(ProductsTestClient.class, server.getURL());
+    }
+
+    @AfterAll
+    void cleanup() {
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    @Nested
+    public class GetAll {
+
+        @Test
+        public void happyPath() {
+            // given
+
+            // when
+            List<ProductDto> result = classUnderTest.getAll();
+
+            // then
+            assertThat(result).hasSize(4);
+            assertThat(result)
+                    .extracting(ProductDto::getCode)
+                    .containsExactlyInAnyOrder("CAR", "FAI", "HSI", "TRI");
+
+            Map<String, ProductDto> productsByCode = result.stream()
+                    .collect(Collectors.toMap(ProductDto::getCode, Function.identity()));
+
+            assertThat(productsByCode.get("CAR"))
+                    .satisfies(product -> {
+                        assertThat(product.getName()).isEqualTo("Happy Driver");
+                        assertThat(product.getCovers()).hasSize(1);
+                        assertThat(product.getQuestions()).hasSize(1);
+                        assertThat(product.getMaxNumberOfInsured()).isEqualTo(1);
+                        assertThat(product.getIcon()).isEqualTo("car");
+                    });
+
+            assertThat(productsByCode.get("FAI"))
+                    .satisfies(product -> {
+                        assertThat(product.getName()).isEqualTo("Happy farm");
+                        assertThat(product.getCovers()).hasSize(4);
+                        assertThat(product.getQuestions()).hasSize(4);
+                        assertThat(product.getMaxNumberOfInsured()).isEqualTo(1);
+                        assertThat(product.getIcon()).isEqualTo("apple");
+                    });
+
+            assertThat(productsByCode.get("HSI"))
+                    .satisfies(product -> {
+                        assertThat(product.getName()).isEqualTo("Happy House");
+                        assertThat(product.getCovers()).hasSize(4);
+                        assertThat(product.getQuestions()).hasSize(4);
+                        assertThat(product.getMaxNumberOfInsured()).isEqualTo(5);
+                        assertThat(product.getIcon()).isEqualTo("building");
+                    });
+
+            assertThat(productsByCode.get("TRI"))
+                    .satisfies(product -> {
+                        assertThat(product.getName()).isEqualTo("Safe Traveller");
+                        assertThat(product.getCovers()).hasSize(3);
+                        assertThat(product.getQuestions()).hasSize(3);
+                        assertThat(product.getMaxNumberOfInsured()).isEqualTo(10);
+                        assertThat(product.getIcon()).isEqualTo("plane");
+                    });
+        }
+    }
+}

--- a/legacy/product-service/src/test/java/pl/altkom/asc/lab/micronaut/poc/product/service/infrastructure/adapters/web/ProductsTestClient.java
+++ b/legacy/product-service/src/test/java/pl/altkom/asc/lab/micronaut/poc/product/service/infrastructure/adapters/web/ProductsTestClient.java
@@ -1,0 +1,17 @@
+package pl.altkom.asc.lab.micronaut.poc.product.service.infrastructure.adapters.web;
+
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.client.annotation.Client;
+import pl.altkom.asc.lab.micronaut.poc.product.service.api.v1.ProductDto;
+
+import java.util.List;
+
+@Client("/products")
+public interface ProductsTestClient {
+
+    @Get
+    List<ProductDto> getAll();
+
+    @Get("/{productCode}")
+    ProductDto get(String productCode);
+}

--- a/legacy/product-service/src/test/resources/application-test.yml
+++ b/legacy/product-service/src/test/resources/application-test.yml
@@ -1,0 +1,6 @@
+micronaut:
+  server:
+    port: -1
+tracing:
+  zipkin:
+    enabled: false


### PR DESCRIPTION
### Summary
This PR establishes a behavior baseline for `legacy/product-service` before the Phase 3 MongoDB-to-PostgreSQL migration by adding automated integration coverage for current happy-path product APIs and startup demo-data seeding behavior. It captures the observable contract for `GET /products` and `GET /products/{productCode}` without changing production behavior.

### Key Changes
- **Product-service baseline integration tests**
  - Added `legacy/product-service/src/test/java/.../ProductsControllerIT.java` to validate:
    - `GET /products` returns seeded demo products (`CAR`, `FAI`, `HSI`, `TRI`) with expected DTO-relevant fields (`code`, `name`, `covers`, `questions`, `maxNumberOfInsured`, `icon`)
    - `GET /products/{productCode}` happy path for known seeded product (`TRI`) with expected DTO-relevant fields
- **Test-only repository wiring for deterministic startup seeding checks**
  - Added `legacy/product-service/src/test/java/.../InMemoryProductsRepository.java`
  - Uses `@Replaces(ProductsRepository.class)` to avoid external Mongo dependency during test execution while still exercising startup seeding flow
- **Test client and test config**
  - Added `legacy/product-service/src/test/java/.../ProductsTestClient.java` for endpoint calls
  - Added `legacy/product-service/src/test/resources/application-test.yml` (`micronaut.server.port: -1`, Zipkin tracing disabled)
- **Module test dependency updates (`legacy/product-service/pom.xml`)**
  - Added JUnit 5 test dependencies (`junit-jupiter-api`, `junit-jupiter-engine`)
  - Added `io.micronaut.test:micronaut-test-junit5`
  - Added `org.assertj:assertj-core:3.24.2` (Java 14-compatible line)
  - Removed legacy JUnit 4 test dependency to keep test provider behavior aligned with JUnit 5
- **Shared Java testing rules update**
  - Updated `ai/rules/java-rules.md` to:
    - prefer AssertJ assertions
    - enforce naming convention: `<ClassName>Test` for unit tests, `<ClassName>IT` for integration tests

### Testing Notes
- Executed from `legacy/product-service`:
  - `mvn org.apache.maven.plugins:maven-surefire-plugin:3.5.4:test -Dtest=ProductsControllerIT -DfailIfNoTests=false`
- Result:
  - `Tests run: 2, Failures: 0, Errors: 0, Skipped: 0`
- Scope note:
  - Coverage is intentionally limited to happy-path contract baseline and startup seeding behavior required by the ticket.
