### PR TITLE
feat: issue-104 switch to postgres persistence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,11 @@ java-all-build: ## Build all Java microservices
 
 .PHONY: frontend-build
 frontend-build: ## Build frontend (Vue app)
+	@NODE_VERSION=$$(node -v); \
+	if [ "$$NODE_VERSION" != "v12.22.12" ]; then \
+		echo "ERROR: Incorrect Node.js version ($$NODE_VERSION). Please use v12.22.12 (hint: nvm use 12.22.12)"; \
+		exit 1; \
+	fi
 	@echo "Building frontend (Vue app)..."
 	@bash legacy/build-frontend.sh
 	@echo "✅ Frontend (Vue app) built successfully."
@@ -78,6 +83,7 @@ docker-java-svc-build: _svc-name-check ## Build a Docker image for a Java servic
 	fi; \
 	echo "🔨 Building Docker image for Java service '$(SVC_NAME)' from '$$SVC_FOLDER'..."; \
 	docker build --no-cache -f "$$SVC_FOLDER/Dockerfile" "$$SVC_FOLDER" -t "$$IMAGE_NAME"; \
+	docker image prune -f; \
 	echo "✅ Docker image '$$IMAGE_NAME' built successfully."
 
 .PHONY: docker-java-svc-all-build
@@ -99,3 +105,12 @@ docker-frontend-build: ## Build the Docker image for the Vue frontend in the 'le
 	docker build --no-cache -f "$$SVC_FOLDER/Dockerfile" "$$SVC_FOLDER" -t "$$IMAGE_NAME"; \
 	docker image prune -f; \
 	echo "✅ Docker image '$$IMAGE_NAME' built successfully."
+
+.PHONY: legacy-all-build
+legacy-all-build: ## Build all legacy artifacts sequentially (Java -> Frontend -> Docker). Usage: legacy-all-build
+	@echo "🚀 Building all legacy artifacts (Java -> Frontend -> Docker)..."
+	$(MAKE) java-all-build
+	$(MAKE) frontend-build
+	$(MAKE) docker-frontend-build
+	$(MAKE) docker-java-svc-all-build
+	@echo "✅ All legacy artifacts built successfully!"

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -1374,7 +1374,9 @@ cluster-svc-deploy:  _env-check ## Deploy all services into either local-dev or 
 	@echo "🚀 Deploying Insurance Hub services into '$(ENV_NAME)' cluster..."
 
 	# Elasticsearch
-	$(MAKE) es-elastic-user-secret-copy
+	@if [ "$(ENV_NAME)" = "qa" ]; then \
+    	$(MAKE) es-elastic-user-secret-copy ; \
+    fi
 
 	# MinIO Service Tenant Configuration
 	# Document

--- a/k8s/apps/svc/product/base/legacy/kustomization.yaml
+++ b/k8s/apps/svc/product/base/legacy/kustomization.yaml
@@ -13,6 +13,9 @@ configMapGenerator:
     literals:
       - MG_HOST=localhost
       - MG_PORT=27017
+      - PG_HOST=localhost
+      - PG_PORT=5432
+      - PG_DBNAME=product
       - TRACING_ZIPKIN_ENABLED=true
       - ZIPKIN_HOST=localhost
       - ZIPKIN_PORT=9411

--- a/k8s/cluster-apps-how-tos.md
+++ b/k8s/cluster-apps-how-tos.md
@@ -31,17 +31,17 @@ and "Insurance Hub" infrastructure and services.
 
 ## Automated Deployment
 
-> ⚠️ Local dev and/or QA environments are created.
-> - Local dev: `cd bootstrap && make local-dev-create`
-> - QA: `cd bootstrap && make qa-create`
+> ⚠️ Local Dev and/or QA environments are created.
+> - Local Dev: `make -C k8s/bootstrap local-dev-create`
+> - QA: `make -C k8s/bootstrap qa-create`
 
-- **Optional** `make legacy-all-build`
+- **Local Dev** `make legacy-all-build`
 - `cd k8s`
-- **QA**: `make cluster-qa-monitoring-deploy`, then ensure that all pods are running: `kgp --all-namespaces | grep "0/"`
+- **QA**: `make cluster-qa-monitoring-deploy`, then ensure that all pods are running: `kgp --all-namespaces | grep -E -- "-[01]$|-[01] "`
 - **QA**: `make -C bootstrap qa-nodes-snapshot QA_SNAPSHOT_NAME=qa-cluster-monitoring-deploy-<iso-date>`
-- `make cluster-infra-deploy`, then ensure that all pods are running: `kgp --all-namespaces | grep "0/"`
+- `make cluster-infra-deploy`, then ensure that all pods are running: `kgp --all-namespaces | grep -E -- "-[01]$|-[01] "`
 - **QA**: `make -C bootstrap qa-nodes-snapshot QA_SNAPSHOT_NAME=qa-cluster-infra-deploy-<iso-date>` 
-- `make cluster-svc-deploy`, then ensure that all pods are running: `kgp --all-namespaces | grep "0/"`
+- `make cluster-svc-deploy`, then ensure that all pods are running: `kgp --all-namespaces | grep -E -- "-[01]$|-[01] "`
 
 ## Step-by-Step Deployment
 

--- a/k8s/overlays/local-dev/svc/product/legacy/deployment-patch.yaml
+++ b/k8s/overlays/local-dev/svc/product/legacy/deployment-patch.yaml
@@ -26,3 +26,14 @@ spec:
                 secretKeyRef:
                   name: local-dev-mongodb-product-user-creds
                   key: password
+            # Postgres sensitive data
+            - name: PG_USER
+              valueFrom:
+                secretKeyRef:
+                  name: local-dev-postgres-product-user-creds
+                  key: username
+            - name: PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: local-dev-postgres-product-user-creds
+                  key: password

--- a/k8s/overlays/local-dev/svc/product/legacy/kustomization.yaml
+++ b/k8s/overlays/local-dev/svc/product/legacy/kustomization.yaml
@@ -19,4 +19,5 @@ configMapGenerator:
     literals:
       - MG_HOST=local-dev-mongodb-svc.local-dev-all.svc.cluster.local
       - MG_PORT=27017
+      - PG_HOST=local-dev-postgres-product-rw.local-dev-all.svc.cluster.local
       - TRACING_ZIPKIN_ENABLED=false

--- a/legacy/product-service/src/main/java/pl/altkom/asc/lab/micronaut/poc/product/service/domain/Choice.java
+++ b/legacy/product-service/src/main/java/pl/altkom/asc/lab/micronaut/poc/product/service/domain/Choice.java
@@ -2,8 +2,6 @@ package pl.altkom.asc.lab.micronaut.poc.product.service.domain;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.bson.codecs.pojo.annotations.BsonCreator;
-import org.bson.codecs.pojo.annotations.BsonProperty;
 
 @Getter
 @NoArgsConstructor
@@ -11,8 +9,7 @@ public class Choice {
     private String code;
     private String label;
 
-    @BsonCreator
-    public Choice(@BsonProperty("code") String code, @BsonProperty("label") String label) {
+    public Choice(String code, String label) {
         this.code = code;
         this.label = label;
     }

--- a/legacy/product-service/src/main/java/pl/altkom/asc/lab/micronaut/poc/product/service/domain/ChoiceQuestion.java
+++ b/legacy/product-service/src/main/java/pl/altkom/asc/lab/micronaut/poc/product/service/domain/ChoiceQuestion.java
@@ -2,8 +2,6 @@ package pl.altkom.asc.lab.micronaut.poc.product.service.domain;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.bson.codecs.pojo.annotations.BsonCreator;
-import org.bson.codecs.pojo.annotations.BsonProperty;
 
 import java.util.Arrays;
 import java.util.List;
@@ -13,12 +11,11 @@ import java.util.List;
 public class ChoiceQuestion extends Question {
     private List<Choice> choices;
 
-    @BsonCreator
     public ChoiceQuestion(
-            @BsonProperty("code") String code,
-            @BsonProperty("index") int index,
-            @BsonProperty("text") String text,
-            @BsonProperty("choices") List<Choice> choices) {
+            String code,
+            int index,
+            String text,
+            List<Choice> choices) {
         super(code, index, text);
         this.choices = choices;
     }

--- a/legacy/product-service/src/main/java/pl/altkom/asc/lab/micronaut/poc/product/service/domain/Cover.java
+++ b/legacy/product-service/src/main/java/pl/altkom/asc/lab/micronaut/poc/product/service/domain/Cover.java
@@ -2,8 +2,6 @@ package pl.altkom.asc.lab.micronaut.poc.product.service.domain;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.bson.codecs.pojo.annotations.BsonCreator;
-import org.bson.codecs.pojo.annotations.BsonProperty;
 
 import java.math.BigDecimal;
 
@@ -17,13 +15,12 @@ public class Cover {
     private boolean optional;
     private BigDecimal sumInsured;
 
-    @BsonCreator
     public Cover(
-            @BsonProperty("code") String code,
-            @BsonProperty("name") String name,
-            @BsonProperty("description") String description,
-            @BsonProperty("optional") boolean optional,
-            @BsonProperty("sumInsured") BigDecimal sumInsured) {
+            String code,
+            String name,
+            String description,
+            boolean optional,
+            BigDecimal sumInsured) {
         this.code = code;
         this.name = name;
         this.description = description;

--- a/legacy/product-service/src/main/java/pl/altkom/asc/lab/micronaut/poc/product/service/domain/DateQuestion.java
+++ b/legacy/product-service/src/main/java/pl/altkom/asc/lab/micronaut/poc/product/service/domain/DateQuestion.java
@@ -2,17 +2,14 @@ package pl.altkom.asc.lab.micronaut.poc.product.service.domain;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.bson.codecs.pojo.annotations.BsonCreator;
-import org.bson.codecs.pojo.annotations.BsonProperty;
 
 @NoArgsConstructor
 @Getter
 public class DateQuestion extends Question {
-    @BsonCreator
     public DateQuestion(
-            @BsonProperty("code") String code,
-            @BsonProperty("index") int index,
-            @BsonProperty("text") String text) {
+            String code,
+            int index,
+            String text) {
         super(code, index, text);
     }
 }

--- a/legacy/product-service/src/main/java/pl/altkom/asc/lab/micronaut/poc/product/service/domain/NumericQuestion.java
+++ b/legacy/product-service/src/main/java/pl/altkom/asc/lab/micronaut/poc/product/service/domain/NumericQuestion.java
@@ -2,16 +2,13 @@ package pl.altkom.asc.lab.micronaut.poc.product.service.domain;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.bson.codecs.pojo.annotations.BsonCreator;
-import org.bson.codecs.pojo.annotations.BsonProperty;
 
 @NoArgsConstructor
 @Getter
 public class NumericQuestion extends Question {
-    @BsonCreator
-    public NumericQuestion(@BsonProperty("code") String code,
-                           @BsonProperty("index") int index,
-                           @BsonProperty("text") String text) {
+    public NumericQuestion(String code,
+                           int index,
+                           String text) {
         super(code, index, text);
     }
 }

--- a/legacy/product-service/src/main/java/pl/altkom/asc/lab/micronaut/poc/product/service/domain/Product.java
+++ b/legacy/product-service/src/main/java/pl/altkom/asc/lab/micronaut/poc/product/service/domain/Product.java
@@ -2,9 +2,6 @@ package pl.altkom.asc.lab.micronaut.poc.product.service.domain;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.bson.codecs.pojo.annotations.BsonCreator;
-import org.bson.codecs.pojo.annotations.BsonDiscriminator;
-import org.bson.codecs.pojo.annotations.BsonProperty;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -12,7 +9,6 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
-@BsonDiscriminator
 public class Product {
     private String code;
     private String name;
@@ -23,16 +19,15 @@ public class Product {
     private int maxNumberOfInsured;
     private String icon;
 
-    @BsonCreator
     public Product(
-            @BsonProperty("code") String code,
-            @BsonProperty("name") String name,
-            @BsonProperty("image") String image,
-            @BsonProperty("description") String description,
-            @BsonProperty("covers") List<Cover> covers,
-            @BsonProperty("questions") List<Question> questions,
-            @BsonProperty("maxNumberOfInsured") int maxNumberOfInsured,
-            @BsonProperty("icon") String icon) {
+            String code,
+            String name,
+            String image,
+            String description,
+            List<Cover> covers,
+            List<Question> questions,
+            int maxNumberOfInsured,
+            String icon) {
         this.code = code;
         this.name = name;
         this.image = image;

--- a/legacy/product-service/src/main/java/pl/altkom/asc/lab/micronaut/poc/product/service/domain/Question.java
+++ b/legacy/product-service/src/main/java/pl/altkom/asc/lab/micronaut/poc/product/service/domain/Question.java
@@ -2,11 +2,9 @@ package pl.altkom.asc.lab.micronaut.poc.product.service.domain;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.bson.codecs.pojo.annotations.BsonDiscriminator;
 
 @NoArgsConstructor
 @Getter
-@BsonDiscriminator
 public class Question {
     private String code;
     private int index;

--- a/legacy/product-service/src/main/java/pl/altkom/asc/lab/micronaut/poc/product/service/init/DataLoader.java
+++ b/legacy/product-service/src/main/java/pl/altkom/asc/lab/micronaut/poc/product/service/init/DataLoader.java
@@ -7,7 +7,7 @@ import pl.altkom.asc.lab.micronaut.poc.product.service.domain.Product;
 import pl.altkom.asc.lab.micronaut.poc.product.service.domain.Products;
 
 import javax.inject.Singleton;
-import java.util.List;
+import java.util.function.Supplier;
 
 @Singleton
 @RequiredArgsConstructor
@@ -17,22 +17,15 @@ public class DataLoader implements ApplicationEventListener<ServerStartupEvent> 
 
     @Override
     public void onApplicationEvent(ServerStartupEvent serverStartupEvent) {
-        List<Product> allProducts = productsRepository.findAll().blockingGet();
+        seedIfMissing("CAR", DemoProductsFactory::car);
+        seedIfMissing("FAI", DemoProductsFactory::farm);
+        seedIfMissing("HSI", DemoProductsFactory::house);
+        seedIfMissing("TRI", DemoProductsFactory::travel);
+    }
 
-        if (allProducts.stream().noneMatch(p -> p.getCode().equals("CAR"))) {
-            productsRepository.add(DemoProductsFactory.car()).blockingGet();
-        }
-
-        if (allProducts.stream().noneMatch(p -> p.getCode().equals("FAI"))) {
-            productsRepository.add(DemoProductsFactory.farm()).blockingGet();
-        }
-
-        if (allProducts.stream().noneMatch(p -> p.getCode().equals("HSI"))) {
-            productsRepository.add(DemoProductsFactory.house()).blockingGet();
-        }
-
-        if (allProducts.stream().noneMatch(p -> p.getCode().equals("TRI"))) {
-            productsRepository.add(DemoProductsFactory.travel()).blockingGet();
+    private void seedIfMissing(String productCode, Supplier<Product> productSupplier) {
+        if (productsRepository.findOne(productCode).blockingGet() == null) {
+            productsRepository.add(productSupplier.get()).blockingGet();
         }
     }
 }

--- a/legacy/product-service/src/main/java/pl/altkom/asc/lab/micronaut/poc/product/service/init/DataLoader.java
+++ b/legacy/product-service/src/main/java/pl/altkom/asc/lab/micronaut/poc/product/service/init/DataLoader.java
@@ -3,12 +3,14 @@ package pl.altkom.asc.lab.micronaut.poc.product.service.init;
 import io.micronaut.context.event.ApplicationEventListener;
 import io.micronaut.runtime.server.event.ServerStartupEvent;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import pl.altkom.asc.lab.micronaut.poc.product.service.domain.Product;
 import pl.altkom.asc.lab.micronaut.poc.product.service.domain.Products;
 
 import javax.inject.Singleton;
 import java.util.function.Supplier;
 
+@Slf4j
 @Singleton
 @RequiredArgsConstructor
 public class DataLoader implements ApplicationEventListener<ServerStartupEvent> {
@@ -17,15 +19,20 @@ public class DataLoader implements ApplicationEventListener<ServerStartupEvent> 
 
     @Override
     public void onApplicationEvent(ServerStartupEvent serverStartupEvent) {
+        log.info("Starting data seeding...");
         seedIfMissing("CAR", DemoProductsFactory::car);
         seedIfMissing("FAI", DemoProductsFactory::farm);
         seedIfMissing("HSI", DemoProductsFactory::house);
         seedIfMissing("TRI", DemoProductsFactory::travel);
+        log.info("Data seeding finished.");
     }
 
     private void seedIfMissing(String productCode, Supplier<Product> productSupplier) {
         if (productsRepository.findOne(productCode).blockingGet() == null) {
+            log.info("Product {} missing. Seeding...", productCode);
             productsRepository.add(productSupplier.get()).blockingGet();
+        } else {
+            log.info("Product {} already exists.", productCode);
         }
     }
 }

--- a/legacy/product-service/src/main/resources/application-local.yml
+++ b/legacy/product-service/src/main/resources/application-local.yml
@@ -7,7 +7,7 @@ mongodb:
   uri: "mongodb://product:mongoProductUserPwd@localhost:27017/products-demo"
 ---
 products:
-  persistence: mongo
+  persistence: postgres
 ---
 postgres:
   host: localhost

--- a/legacy/product-service/src/main/resources/application.yml
+++ b/legacy/product-service/src/main/resources/application.yml
@@ -18,7 +18,7 @@ mongodb:
       maxSize: 20
 ---
 products:
-  persistence: ${PRODUCTS_PERSISTENCE:mongo}
+  persistence: ${PRODUCTS_PERSISTENCE:postgres}
 ---
 postgres:
   host: ${PG_HOST:localhost}

--- a/legacy/product-service/src/test/java/pl/altkom/asc/lab/micronaut/poc/product/service/BaseIT.java
+++ b/legacy/product-service/src/test/java/pl/altkom/asc/lab/micronaut/poc/product/service/BaseIT.java
@@ -2,7 +2,6 @@ package pl.altkom.asc.lab.micronaut.poc.product.service;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.runtime.server.EmbeddedServer;
-import org.junit.jupiter.api.AfterAll;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 import java.util.HashMap;
@@ -34,12 +33,5 @@ public abstract class BaseIT {
         properties.put("datasources.default.password", postgresqlContainer.getPassword());
         properties.putAll(extraProperties);
         return ApplicationContext.run(EmbeddedServer.class, properties);
-    }
-
-    @AfterAll
-    static void stopPostgres() {
-        if (postgresqlContainer != null) {
-            postgresqlContainer.stop();
-        }
     }
 }

--- a/legacy/product-service/src/test/java/pl/altkom/asc/lab/micronaut/poc/product/service/infrastructure/adapters/db/PostgresProductsRepositoryIT.java
+++ b/legacy/product-service/src/test/java/pl/altkom/asc/lab/micronaut/poc/product/service/infrastructure/adapters/db/PostgresProductsRepositoryIT.java
@@ -17,9 +17,7 @@ import pl.altkom.asc.lab.micronaut.poc.product.service.domain.Products;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -32,11 +30,7 @@ public class PostgresProductsRepositoryIT extends BaseIT {
 
     @BeforeAll
     void setup() {
-        Map<String, Object> properties = new HashMap<>();
-        properties.put("products.persistence", "postgres");
-        properties.put("jpa.default.enabled", true);
-        properties.put("jpa.default.properties.hibernate.hbm2ddl.auto", "create-drop");
-        server = startServer(properties);
+        server = startServer();
         classUnderTest = server.getApplicationContext().getBean(Products.class);
         postgresRepository = server.getApplicationContext().getBean(PostgresProductsRepository.class);
     }

--- a/legacy/product-service/src/test/java/pl/altkom/asc/lab/micronaut/poc/product/service/infrastructure/adapters/web/ProductsControllerIT.java
+++ b/legacy/product-service/src/test/java/pl/altkom/asc/lab/micronaut/poc/product/service/infrastructure/adapters/web/ProductsControllerIT.java
@@ -1,15 +1,14 @@
 package pl.altkom.asc.lab.micronaut.poc.product.service.infrastructure.adapters.web;
 
-import io.micronaut.context.ApplicationContext;
 import io.micronaut.runtime.server.EmbeddedServer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import pl.altkom.asc.lab.micronaut.poc.product.service.BaseIT;
 import pl.altkom.asc.lab.micronaut.poc.product.service.api.v1.ProductDto;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -18,16 +17,14 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class ProductsControllerIT {
+public class ProductsControllerIT extends BaseIT {
 
     private ProductsTestClient classUnderTest;
     private EmbeddedServer server;
 
     @BeforeAll
     void setup() {
-        Map<String, Object> properties = new HashMap<>();
-        properties.put("micronaut.environments", "test");
-        server = ApplicationContext.run(EmbeddedServer.class, properties);
+        server = startServer();
         classUnderTest = server.getApplicationContext().createBean(ProductsTestClient.class, server.getURL());
     }
 

--- a/legacy/product-service/src/test/java/pl/altkom/asc/lab/micronaut/poc/product/service/init/DataLoaderTest.java
+++ b/legacy/product-service/src/test/java/pl/altkom/asc/lab/micronaut/poc/product/service/init/DataLoaderTest.java
@@ -1,0 +1,51 @@
+package pl.altkom.asc.lab.micronaut.poc.product.service.init;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import pl.altkom.asc.lab.micronaut.poc.product.service.domain.Product;
+import pl.altkom.asc.lab.micronaut.poc.product.service.infrastructure.adapters.db.InMemoryProductsRepository;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DataLoaderTest {
+
+    private final InMemoryProductsRepository productsRepository = new InMemoryProductsRepository();
+    private final DataLoader classUnderTest = new DataLoader(productsRepository);
+
+    @Nested
+    public class OnApplicationEvent {
+
+        @Test
+        public void happyPath() {
+            // given
+
+            // when
+            classUnderTest.onApplicationEvent(null);
+            List<Product> result = productsRepository.findAll().blockingGet();
+
+            // then
+            assertThat(result).hasSize(4);
+            assertThat(result)
+                    .extracting(Product::getCode)
+                    .containsExactlyInAnyOrder("CAR", "FAI", "HSI", "TRI");
+        }
+
+        @Test
+        public void givenAlreadySeededCatalog_thenReplayingStartupDoesNotDuplicateProducts() {
+            // given
+            classUnderTest.onApplicationEvent(null);
+
+            // when
+            classUnderTest.onApplicationEvent(null);
+            List<Product> result = productsRepository.findAll().blockingGet();
+
+            // then
+            assertThat(result).hasSize(4);
+            assertThat(result)
+                    .extracting(Product::getCode)
+                    .containsExactlyInAnyOrder("CAR", "FAI", "HSI", "TRI");
+        }
+    }
+}

--- a/legacy/product-service/src/test/resources/application-test.yml
+++ b/legacy/product-service/src/test/resources/application-test.yml
@@ -8,16 +8,17 @@ datasources:
 ---
 jpa:
   default:
+    enabled: true
     properties:
       hibernate:
+        hbm2ddl:
+          auto: create-drop
         dialect: org.hibernate.dialect.PostgreSQL10Dialect
         temp:
           use_jdbc_metadata_defaults: false
-        hbm2ddl:
-          auto: none
 ---
 products:
-  persistence: mongo
+  persistence: postgres
 ---
 tracing:
   zipkin:


### PR DESCRIPTION
### Summary
This PR cuts over `legacy/product-service` from MongoDB-backed product persistence to PostgreSQL-backed persistence while preserving the existing REST contract. It also removes MongoDB BSON annotations from the shared domain model, makes startup seeding idempotent against PostgreSQL, and updates the test setup so the controller and repository integration tests run on the PostgreSQL-default path.

### Key Changes
- **PostgreSQL runtime cutover in `product-service`**
  - Switched the default `products.persistence` value to `postgres` in `legacy/product-service/src/main/resources/application.yml` and `application-local.yml`.
  - Kept the Mongo repository implementation in place, but no longer as the default runtime path.
- **Mongo-specific domain cleanup**
  - Removed BSON annotations and imports from the shared domain model:
    - `Product`
    - `Cover`
    - `Question`
    - `ChoiceQuestion`
    - `NumericQuestion`
    - `DateQuestion`
    - `Choice`
  - Preserved the constructor shape and fields used by the PostgreSQL JSONB mapping layer.
- **Startup seeding update**
  - Refactored `DataLoader` to seed demo products by code lookup instead of loading the entire catalog first.
  - Kept seeding idempotent for repeated startup runs.
- **Test and validation alignment**
  - Updated `application-test.yml` to default the test profile to PostgreSQL and enable JPA schema creation.
  - Reworked `ProductsControllerIT` to use the shared PostgreSQL Testcontainers bootstrap from `BaseIT`.
  - Simplified `PostgresProductsRepositoryIT` to rely on the shared PostgreSQL test defaults.
  - Fixed the shared `BaseIT` lifecycle so the PostgreSQL container remains available across the full integration test run.
  - Added `DataLoaderTest` to cover seeding and replay/idempotency behavior.

### Testing Notes
- Validated by deploying the Docker image to the local dev cluster and reviewing the application logs.
- Connected to the product PostgreSQL instance and verified the contents of the `product` table.
<img width="1581" height="846" alt="image" src="https://github.com/user-attachments/assets/33732e58-78ae-4f45-85d7-18fc4d122119" />
